### PR TITLE
Add javax.xml.bind to pom

### DIFF
--- a/anki-vocabulary-assistant/pom.xml
+++ b/anki-vocabulary-assistant/pom.xml
@@ -22,6 +22,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+	<dependency>
+	  <groupId>javax.xml.bind</groupId>
+	  <artifactId>jaxb-api</artifactId>
+	  <version>2.3.0</version>
+	</dependency>
         <!--<dependency>-->
             <!--<groupId>com.google.api-client</groupId>-->
             <!--<artifactId>google-api-client</artifactId>-->


### PR DESCRIPTION
Without this, java.lang.NoClassDefFoundError occurs due to
missing javax/xml/bind/ValidationException

Solution found in https://stackoverflow.com/questions/43574426